### PR TITLE
[Session/3] StatefulWidget のライフサイクル

### DIFF
--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -15,7 +16,7 @@ class _LaunchScreenState extends State<LaunchScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(_showWeatherAfterRendering);
+    unawaited(_showWeatherAfterRendering());
   }
 
   Future<void> _showWeatherAfterRendering() async {

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -35,8 +35,8 @@ class _LaunchScreenState extends State<LaunchScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Container(
+    return const Scaffold(
+      body: ColoredBox(
         color: Colors.green,
       ),
     );

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class LaunchScreen extends StatefulWidget {
   const LaunchScreen({super.key});
@@ -8,6 +9,27 @@ class LaunchScreen extends StatefulWidget {
 }
 
 class _LaunchScreenState extends State<LaunchScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_showWeatherAfterRendering);
+  }
+
+  Future<void> _showWeatherAfterRendering() async {
+    await WidgetsBinding.instance.endOfFrame;
+    await _showWeather();
+  }
+
+  Future<void> _showWeather() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (mounted) {
+      await context.push('/weather');
+      // WeatherScreen にて "Close" が押された場合や iOS のエッジスワイプで戻った際に
+      // 再度 WeatherScreen を表示するために再帰呼び出し
+      await _showWeather();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class LaunchScreen extends StatefulWidget {
+  const LaunchScreen({super.key});
+
+  @override
+  State<LaunchScreen> createState() => _LaunchScreenState();
+}
+
+class _LaunchScreenState extends State<LaunchScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        color: Colors.green,
+      ),
+    );
+  }
+}

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 
 class LaunchScreen extends StatefulWidget {
-  const LaunchScreen({super.key});
+  const LaunchScreen({required AsyncCallback showWeather, super.key})
+      : _showWeather = showWeather;
+
+  final AsyncCallback _showWeather;
 
   @override
   State<LaunchScreen> createState() => _LaunchScreenState();
@@ -23,7 +26,7 @@ class _LaunchScreenState extends State<LaunchScreen> {
   Future<void> _showWeather() async {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (mounted) {
-      await context.push('/weather');
+      await widget._showWeather();
       // WeatherScreen にて "Close" が押された場合や iOS のエッジスワイプで戻った際に
       // 再度 WeatherScreen を表示するために再帰呼び出し
       await _showWeather();

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -39,6 +39,7 @@ class _LaunchScreenState extends State<LaunchScreen> {
     return const Scaffold(
       body: ColoredBox(
         color: Colors.green,
+        child: SizedBox.expand(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/weather/use_case/get_weather.dart';
-import 'package:flutter_training/weather/weather_screen.dart';
+import 'package:flutter_training/router.dart';
 
 void main() {
   runApp(const App());
@@ -11,14 +10,14 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Weather App',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.blue,
         ),
       ),
-      home: const WeatherScreen(GetWeather()),
+      routerConfig: router,
     );
   }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_training/launch/launch_screen.dart';
+import 'package:flutter_training/weather/use_case/get_weather.dart';
+import 'package:flutter_training/weather/weather_screen.dart';
 import 'package:go_router/go_router.dart';
 
 final router = GoRouter(
@@ -6,6 +8,10 @@ final router = GoRouter(
     GoRoute(
       path: '/',
       builder: (context, state) => const LaunchScreen(),
+    ),
+    GoRoute(
+      path: '/weather',
+      builder: (context, state) => const WeatherScreen(GetWeather()),
     ),
   ],
 );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -3,15 +3,25 @@ import 'package:flutter_training/weather/use_case/get_weather.dart';
 import 'package:flutter_training/weather/weather_screen.dart';
 import 'package:go_router/go_router.dart';
 
+const _path = (
+  launch: '/',
+  weather: '/weather',
+);
+
 final router = GoRouter(
   routes: [
     GoRoute(
-      path: '/',
-      builder: (context, state) => const LaunchScreen(),
+      path: _path.launch,
+      builder: (context, state) => LaunchScreen(
+        showWeather: () => context.push(_path.weather),
+      ),
     ),
     GoRoute(
-      path: '/weather',
-      builder: (context, state) => const WeatherScreen(GetWeather()),
+      path: _path.weather,
+      builder: (context, state) => WeatherScreen(
+        const GetWeather(),
+        close: () => context.pop(),
+      ),
     ),
   ],
 );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_training/launch/launch_screen.dart';
+import 'package:go_router/go_router.dart';
+
+final router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const LaunchScreen(),
+    ),
+  ],
+);

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -6,7 +6,7 @@ import 'package:go_router/go_router.dart';
 
 class WeatherScreen extends StatefulWidget {
   const WeatherScreen(GetWeather getWeather, {super.key})
-    : _getWeather = getWeather;
+      : _getWeather = getWeather;
 
   final GetWeather _getWeather;
 
@@ -61,7 +61,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
 
 class _ForecastContent extends StatelessWidget {
   const _ForecastContent({WeatherCondition? weatherCondition})
-    : _weatherCondition = weatherCondition;
+      : _weatherCondition = weatherCondition;
 
   final WeatherCondition? _weatherCondition;
 
@@ -105,9 +105,11 @@ class _ForecastContent extends StatelessWidget {
 }
 
 class _ButtonsRow extends StatelessWidget {
-  const _ButtonsRow({required VoidCallback closeAction, required VoidCallback reloadAction})
-    : _closeAction = closeAction,
-      _reloadAction = reloadAction;
+  const _ButtonsRow({
+    required VoidCallback closeAction,
+    required VoidCallback reloadAction,
+  })  : _closeAction = closeAction,
+        _reloadAction = reloadAction;
 
   final VoidCallback _closeAction;
   final VoidCallback _reloadAction;

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -2,13 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_training/data/weather_condition.dart';
 import 'package:flutter_training/weather/use_case/get_weather.dart';
 import 'package:flutter_training/weather/weather_icon.dart';
-import 'package:go_router/go_router.dart';
 
 class WeatherScreen extends StatefulWidget {
-  const WeatherScreen(GetWeather getWeather, {super.key})
-      : _getWeather = getWeather;
+  const WeatherScreen(
+    GetWeather getWeather, {
+    required VoidCallback close,
+    super.key,
+  })  : _getWeather = getWeather,
+        _close = close;
 
   final GetWeather _getWeather;
+  final VoidCallback _close;
 
   @override
   State<WeatherScreen> createState() => _WeatherScreenState();
@@ -38,9 +42,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
                   child: Padding(
                     padding: const EdgeInsets.only(top: 80),
                     child: _ButtonsRow(
-                      closeAction: () {
-                        context.pop();
-                      },
+                      closeAction: widget._close,
                       reloadAction: () {
                         final weatherCondition = widget._getWeather();
                         setState(() {

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_training/data/weather_condition.dart';
 import 'package:flutter_training/weather/use_case/get_weather.dart';
 import 'package:flutter_training/weather/weather_icon.dart';
+import 'package:go_router/go_router.dart';
 
 class WeatherScreen extends StatefulWidget {
   const WeatherScreen(GetWeather getWeather, {super.key})
@@ -37,6 +38,9 @@ class _WeatherScreenState extends State<WeatherScreen> {
                   child: Padding(
                     padding: const EdgeInsets.only(top: 80),
                     child: _ButtonsRow(
+                      closeAction: () {
+                        context.pop();
+                      },
                       reloadAction: () {
                         final weatherCondition = widget._getWeather();
                         setState(() {
@@ -101,9 +105,11 @@ class _ForecastContent extends StatelessWidget {
 }
 
 class _ButtonsRow extends StatelessWidget {
-  const _ButtonsRow({required VoidCallback reloadAction})
-    : _reloadAction = reloadAction;
+  const _ButtonsRow({required VoidCallback closeAction, required VoidCallback reloadAction})
+    : _closeAction = closeAction,
+      _reloadAction = reloadAction;
 
+  final VoidCallback _closeAction;
   final VoidCallback _reloadAction;
 
   @override
@@ -112,7 +118,7 @@ class _ButtonsRow extends StatelessWidget {
       children: [
         Expanded(
           child: TextButton(
-            onPressed: () {},
+            onPressed: _closeAction,
             child: const Text(
               'Close',
               textAlign: TextAlign.center,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,6 +83,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "7685acd06244ba4be60f455c5cafe5790c63dc91fc03f7385b1e922a6b85b17c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.1.1"
   http:
     dependency: transitive
     description:
@@ -123,6 +136,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.10+1
+  go_router: ^14.1.1
   yumemi_weather:
     git:
       url: https://github.com/yumemi-inc/flutter-training-template.git


### PR DESCRIPTION
## 課題

close #4

- go_router を利用した画面遷移を実装。
- `LaunchScreen` を追加し、この Widget の表示の検知には `WidgetsBinding.instance.endOfFrame` を利用。

## 対応箇所

- [x] StatefulWidget を継承した Widget で構築された新しい画面を追加する
- [x] 新しい画面の背景色は `Colors.green` に設定する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| <img width=300 src="https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/lifecycle/demo.gif?raw=true&rgh-link-date=2024-05-08T01%3A34%3A00Z">      | <video width=300 src="https://github.com/daichikuwa0618/flutter-weather-app/assets/31601805/b0db44f4-f788-4390-9836-10446fab1399">    |

