### PR TITLE
[Issue-#5] 画面表示状態に応じて処理が可能な `AfterLayoutMixin` を追加

### DIFF
--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -15,17 +15,13 @@ class LaunchScreen extends StatefulWidget {
 
 class _LaunchScreenState extends State<LaunchScreen> with AfterLayoutMixin {
   @override
-  void didLayoutEnded() {
-    unawaited(_showWeather());
-  }
-
-  Future<void> _showWeather() async {
+  Future<void> didLayoutEnded() async {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (mounted) {
       await widget._showWeather();
       // WeatherScreen にて "Close" が押された場合や iOS のエッジスワイプで戻った際に
       // 再度 WeatherScreen を表示するために再帰呼び出し
-      await _showWeather();
+      await didLayoutEnded();
     }
   }
 

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_training/util/layout_state_mixin.dart';
+import 'package:flutter_training/util/after_layout_mixin.dart';
 
 class LaunchScreen extends StatefulWidget {
   const LaunchScreen({required AsyncCallback showWeather, super.key})
@@ -13,7 +13,7 @@ class LaunchScreen extends StatefulWidget {
   State<LaunchScreen> createState() => _LaunchScreenState();
 }
 
-class _LaunchScreenState extends State<LaunchScreen> with LayoutStateMixin {
+class _LaunchScreenState extends State<LaunchScreen> with AfterLayoutMixin {
   @override
   void didLayoutEnded() {
     unawaited(_showWeather());

--- a/lib/launch/launch_screen.dart
+++ b/lib/launch/launch_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_training/util/layout_state_mixin.dart';
 
 class LaunchScreen extends StatefulWidget {
   const LaunchScreen({required AsyncCallback showWeather, super.key})
@@ -12,16 +13,10 @@ class LaunchScreen extends StatefulWidget {
   State<LaunchScreen> createState() => _LaunchScreenState();
 }
 
-class _LaunchScreenState extends State<LaunchScreen> {
+class _LaunchScreenState extends State<LaunchScreen> with LayoutStateMixin {
   @override
-  void initState() {
-    super.initState();
-    unawaited(_showWeatherAfterRendering());
-  }
-
-  Future<void> _showWeatherAfterRendering() async {
-    await WidgetsBinding.instance.endOfFrame;
-    await _showWeather();
+  void didLayoutEnded() {
+    unawaited(_showWeather());
   }
 
   Future<void> _showWeather() async {

--- a/lib/util/after_layout_mixin.dart
+++ b/lib/util/after_layout_mixin.dart
@@ -12,6 +12,8 @@ mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
 
   Future<void> _asyncInitState() async {
     await WidgetsBinding.instance.endOfFrame;
-    didLayoutEnded();
+    if (mounted) {
+      didLayoutEnded();
+    }
   }
 }

--- a/lib/util/after_layout_mixin.dart
+++ b/lib/util/after_layout_mixin.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
-  void didLayoutEnded();
+  FutureOr<void> didLayoutEnded();
 
   @override
   void initState() {
@@ -13,7 +13,7 @@ mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
   Future<void> _asyncInitState() async {
     await WidgetsBinding.instance.endOfFrame;
     if (mounted) {
-      didLayoutEnded();
+      await didLayoutEnded();
     }
   }
 }

--- a/lib/util/after_layout_mixin.dart
+++ b/lib/util/after_layout_mixin.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 
-mixin LayoutStateMixin<T extends StatefulWidget> on State<T> {
+mixin AfterLayoutMixin<T extends StatefulWidget> on State<T> {
   void didLayoutEnded();
 
   @override

--- a/lib/util/layout_state_mixin.dart
+++ b/lib/util/layout_state_mixin.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+mixin LayoutStateMixin<T extends StatefulWidget> on State<T> {
+  void didLayoutEnded();
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_asyncInitState());
+  }
+
+  Future<void> _asyncInitState() async {
+    await WidgetsBinding.instance.endOfFrame;
+    didLayoutEnded();
+  }
+}


### PR DESCRIPTION
## 課題

close #5 

## 対応箇所

- [x] レイアウトが表示された後に「何かしらの処理」を行う Mixin を作成する
- [x] 作成した Mixin の使用先で「何かしらの処理」を記述できるようにする
- [x] Session3 で作成した以下の処理を作成した Mixin を使って書き直す
  > 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する

## 動作
 
変更ないためスキップ
