### PR TITLE
[Session/5] 天気情報取得時の例外発生時に AlertDialog を表示する

### DIFF
--- a/lib/weather/use_case/get_weather.dart
+++ b/lib/weather/use_case/get_weather.dart
@@ -4,8 +4,8 @@ import 'package:yumemi_weather/yumemi_weather.dart';
 final class GetWeather {
   const GetWeather();
 
-  WeatherCondition call() {
-    final response = YumemiWeather().fetchSimpleWeather();
+  WeatherCondition call({required String area}) {
+    final response = YumemiWeather().fetchThrowsWeather(area);
     return WeatherCondition.values.byName(response);
   }
 }

--- a/lib/weather/use_case/get_weather.dart
+++ b/lib/weather/use_case/get_weather.dart
@@ -1,11 +1,48 @@
 import 'package:flutter_training/data/weather_condition.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
+sealed class GetWeatherException implements Exception {
+  const GetWeatherException({YumemiWeatherError? rawError})
+      : _rawError = rawError;
+
+  final YumemiWeatherError? _rawError;
+
+  @override
+  String toString() => _rawError.toString();
+}
+
+final class UnknownException extends GetWeatherException {
+  const UnknownException({super.rawError});
+
+  @override
+  String toString() => 'Unknown Exception: $_rawError';
+}
+
+final class InvalidParameterException extends GetWeatherException {
+  const InvalidParameterException({super.rawError});
+
+  @override
+  String toString() => 'Parameter is not valid: $_rawError';
+}
+
 final class GetWeather {
   const GetWeather();
 
   WeatherCondition call({required String area}) {
-    final response = YumemiWeather().fetchThrowsWeather(area);
-    return WeatherCondition.values.byName(response);
+    try {
+      final response = YumemiWeather().fetchThrowsWeather(area);
+      return WeatherCondition.values.byName(response);
+    } on YumemiWeatherError catch(e) {
+      switch (e) {
+        case YumemiWeatherError.unknown:
+          throw UnknownException(rawError: e);
+
+        case YumemiWeatherError.invalidParameter:
+          throw InvalidParameterException(rawError: e);
+      }
+    } on Exception catch(_) {
+      assert(false, 'Unexpected Exception');
+      throw const UnknownException();
+    }
   }
 }

--- a/lib/weather/use_case/get_weather.dart
+++ b/lib/weather/use_case/get_weather.dart
@@ -15,14 +15,14 @@ final class UnknownException extends GetWeatherException {
   const UnknownException({super.rawError});
 
   @override
-  String toString() => 'Unknown Exception: $_rawError';
+  String toString() => 'Unknown Exception: ${super.toString()}';
 }
 
 final class InvalidParameterException extends GetWeatherException {
   const InvalidParameterException({super.rawError});
 
   @override
-  String toString() => 'Parameter is not valid: $_rawError';
+  String toString() => 'Parameter is not valid: ${super.toString()}';
 }
 
 final class GetWeather {

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -63,12 +63,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
         _weatherCondition = weatherCondition;
       });
     } on GetWeatherException catch(e) {
-      final message = switch (e) {
-        UnknownException() => 'Unknown error occurred. Please try again.',
-        InvalidParameterException() =>
-          'Parameter is not valid. Please check your inputs and try again.',
-      };
-      unawaited(_showErrorDialog(message));
+      unawaited(_showErrorDialog(e.message));
     }
   }
 
@@ -169,5 +164,15 @@ class _ButtonsRow extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+extension on GetWeatherException {
+  String get message {
+    return switch (this) {
+      UnknownException() => 'Unknown error occurred. Please try again.',
+      InvalidParameterException() =>
+      'Parameter is not valid. Please check your inputs and try again.',
+    };
   }
 }

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -43,14 +43,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
                     padding: const EdgeInsets.only(top: 80),
                     child: _ButtonsRow(
                       closeAction: widget._close,
-                      reloadAction: () {
-                        final weatherCondition = widget._getWeather(
-                          area: 'tokyo',
-                        );
-                        setState(() {
-                          _weatherCondition = weatherCondition;
-                        });
-                      },
+                      reloadAction: _reloadWeather,
                     ),
                   ),
                 ),
@@ -60,6 +53,23 @@ class _WeatherScreenState extends State<WeatherScreen> {
         ),
       ),
     );
+  }
+
+  void _reloadWeather() {
+    try {
+      final weatherCondition = widget._getWeather(area: 'tokyo');
+      setState(() {
+        _weatherCondition = weatherCondition;
+      });
+    } on GetWeatherException catch(e) {
+      switch (e) {
+        case UnknownException():
+          print(e);
+
+        case InvalidParameterException():
+          print(e);
+      }
+    }
   }
 }
 

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -44,7 +44,9 @@ class _WeatherScreenState extends State<WeatherScreen> {
                     child: _ButtonsRow(
                       closeAction: widget._close,
                       reloadAction: () {
-                        final weatherCondition = widget._getWeather();
+                        final weatherCondition = widget._getWeather(
+                          area: 'tokyo',
+                        );
                         setState(() {
                           _weatherCondition = weatherCondition;
                         });

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_training/data/weather_condition.dart';
 import 'package:flutter_training/weather/use_case/get_weather.dart';
@@ -62,14 +63,30 @@ class _WeatherScreenState extends State<WeatherScreen> {
         _weatherCondition = weatherCondition;
       });
     } on GetWeatherException catch(e) {
-      switch (e) {
-        case UnknownException():
-          print(e);
-
-        case InvalidParameterException():
-          print(e);
-      }
+      final message = switch (e) {
+        UnknownException() => 'Unknown error occurred. Please try again.',
+        InvalidParameterException() =>
+          'Parameter is not valid. Please check your inputs and try again.',
+      };
+      unawaited(_showErrorDialog(message));
     }
+  }
+
+  Future<void> _showErrorDialog(String message) async {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        title: const Text('Error'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: Navigator.of(context).pop,
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を `fetchSimpleWeather()` から `fetchThrowsWeather()` に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| <img width=300 src="https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/error/demo.gif?raw=true&rgh-link-date=2024-05-08T01%3A34%3A02Z">  | <video width=300 src="https://github.com/daichikuwa0618/flutter-weather-app/assets/31601805/d367e114-32c1-477e-8037-8f0847121864"> |





