### PR TITLE
[Session/8] riverpod を使った状態管理に変更

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,41 @@
+# アーキテクチャ
+
+## 基本方針
+
+- できる限りシンプルにする。不要なレイヤーは作らない。
+- 抽象化は基本的に行わない。
+  - Dart には暗黙的なインターフェイスが定義されて、インスタンスの差し替えも明示的な抽象化無しで行えるため。
+  - [Classes | Dart](https://dart.dev/language/classes#implicit-interfaces)
+- `router` が各画面 (Feature) の依存解決を行う。
+  - 画面遷移の情報も外から注入可能にしておき `router` に閉じ込める。
+
+## 定義されるレイヤーとレイヤー同士の依存関係
+
+- `router`: 画面遷移、依存解決を行う。どこに依存しても良い。
+- `Features`: 明示的な module ではないが、機能 (基本的には画面) のまとまり
+  - `Screen`:  UI の責務を持つ `Widget`。
+  - `UseCase`: UI から呼び出されるロジックを実装するもの。基本的には 1 Use Case 1 class であり、`call()` メソッドを提供する。
+- `Data`: アプリケーションロジックを持たないモデルをまとめたモジュール。基本的には immutable にしておき `@freezed` で便利関数を拡張する。どこから依存されても良い。
+- `Util`: 共通実装となるモジュール。どこから依存されても良い。
+
+```mermaid
+flowchart TB
+subgraph CM [Commons: Anyone can depend on]
+  direction LR
+  Data ~~~ Util
+end
+
+subgraph Features
+  direction LR
+  Screen --> UseCase
+end
+
+subgraph DS [Data Sources / Infrastructures]
+  YW[(yumemi_weather)]
+end
+
+main.dart --> router
+router -- resolve Screens' dependencies --> Features
+UseCase --> YW
+UseCase ~~~ CM
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,3 +39,36 @@ router -- resolve Screens' dependencies --> Features
 UseCase --> YW
 UseCase ~~~ CM
 ```
+
+## Provider 同士の依存関係
+
+[Session8 · Issue #9 · daichikuwa0618/flutter-weather-app](https://github.com/daichikuwa0618/flutter-weather-app/issues/9) の課題の一環で作成。
+
+```mermaid
+flowchart TB
+  subgraph Arrows
+    direction LR
+    start1[ ] -..->|read| stop1[ ]
+    style start1 height:0px;
+    style stop1 height:0px;
+    start2[ ] --->|listen| stop2[ ]
+    style start2 height:0px;
+    style stop2 height:0px;
+    start3[ ] ===>|watch| stop3[ ]
+    style start3 height:0px;
+    style stop3 height:0px;
+  end
+  subgraph Type
+    direction TB
+    ConsumerWidget((widget));
+    Provider[[provider]];
+  end
+
+  Arrows ~~~ Type
+
+  weatherNotifierProvider[["weatherNotifierProvider"]];
+  WeatherScreen((WeatherScreen));
+
+  weatherNotifierProvider ==> WeatherScreen;
+  weatherNotifierProvider -.-> WeatherScreen;
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # flutter_training
 
 A new Flutter project.
+
+## アーキテクチャ
+
+[ARCHITECTURE.md](ARCHITECTURE.md) 参照。

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,5 @@ include: package:yumemi_lints/flutter/3.19/recommended.yaml
 analyzer:
   errors:
     invalid_annotation_target: ignore
+  plugins:
+    - custom_lint

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_training/router.dart';
 
 void main() {
-  runApp(const App());
+  runApp(
+    const ProviderScope(
+      child: App(),
+    ),
+  );
 }
 
 class App extends StatelessWidget {

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_training/launch/launch_screen.dart';
-import 'package:flutter_training/weather/use_case/get_weather.dart';
 import 'package:flutter_training/weather/weather_screen.dart';
 import 'package:go_router/go_router.dart';
 
@@ -19,7 +18,6 @@ final router = GoRouter(
     GoRoute(
       path: _path.weather,
       builder: (context, state) => WeatherScreen(
-        const GetWeather(),
         close: () => context.pop(),
       ),
     ),

--- a/lib/weather/use_case/get_weather.dart
+++ b/lib/weather/use_case/get_weather.dart
@@ -57,15 +57,10 @@ final class GetWeather {
   }
 }
 
-@freezed
+@Freezed(toJson: true)
 class _Request with _$Request {
   const factory _Request({
     required String area,
     @JsonKey(name: 'date') required DateTime dateTime,
   }) = _RequestData;
-
-  // `fromJson` は `toJson` 生成のための実装で未使用になるのは避けられないため;
-  // ignore: unused_element
-  factory _Request.fromJson(Map<String, Object?> json) =>
-      _$RequestFromJson(json);
 }

--- a/lib/weather/use_case/get_weather.dart
+++ b/lib/weather/use_case/get_weather.dart
@@ -32,27 +32,31 @@ final class InvalidParameterException extends GetWeatherException {
   String toString() => 'Parameter is not valid: ${super.toString()}';
 }
 
+typedef GetWeatherUseCase = Weather Function({required String area});
+
 @riverpod
-Weather getWeather(GetWeatherRef ref, {required String area}) {
-  try {
-    final request = _Request(area: area, dateTime: DateTime.now());
-    final requestJsonString = jsonEncode(request.toJson());
+GetWeatherUseCase getWeather(GetWeatherRef ref) {
+  return ({required area}) {
+    try {
+      final request = _Request(area: area, dateTime: DateTime.now());
+      final requestJsonString = jsonEncode(request.toJson());
 
-    final rawResponse = YumemiWeather().fetchWeather(requestJsonString);
-    final responseJson = jsonDecode(rawResponse) as Map<String, dynamic>;
-    return Weather.fromJson(responseJson);
-  } on YumemiWeatherError catch (e) {
-    switch (e) {
-      case YumemiWeatherError.unknown:
-        throw UnknownException(rawError: e);
+      final rawResponse = YumemiWeather().fetchWeather(requestJsonString);
+      final responseJson = jsonDecode(rawResponse) as Map<String, dynamic>;
+      return Weather.fromJson(responseJson);
+    } on YumemiWeatherError catch (e) {
+      switch (e) {
+        case YumemiWeatherError.unknown:
+          throw UnknownException(rawError: e);
 
-      case YumemiWeatherError.invalidParameter:
-        throw InvalidParameterException(rawError: e);
+        case YumemiWeatherError.invalidParameter:
+          throw InvalidParameterException(rawError: e);
+      }
+    } on Exception catch (_) {
+      assert(false, 'Unexpected Exception');
+      throw const UnknownException();
     }
-  } on Exception catch (_) {
-    assert(false, 'Unexpected Exception');
-    throw const UnknownException();
-  }
+  };
 }
 
 @Freezed(toJson: true)

--- a/lib/weather/use_case/get_weather.freezed.dart
+++ b/lib/weather/use_case/get_weather.freezed.dart
@@ -14,10 +14,6 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
-_Request _$RequestFromJson(Map<String, dynamic> json) {
-  return _RequestData.fromJson(json);
-}
-
 /// @nodoc
 mixin _$Request {
   String get area => throw _privateConstructorUsedError;
@@ -106,13 +102,10 @@ class __$$RequestDataImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-@JsonSerializable()
+@JsonSerializable(createFactory: false)
 class _$RequestDataImpl implements _RequestData {
   const _$RequestDataImpl(
       {required this.area, @JsonKey(name: 'date') required this.dateTime});
-
-  factory _$RequestDataImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RequestDataImplFromJson(json);
 
   @override
   final String area;
@@ -158,9 +151,6 @@ abstract class _RequestData implements _Request {
           {required final String area,
           @JsonKey(name: 'date') required final DateTime dateTime}) =
       _$RequestDataImpl;
-
-  factory _RequestData.fromJson(Map<String, dynamic> json) =
-      _$RequestDataImpl.fromJson;
 
   @override
   String get area;

--- a/lib/weather/use_case/get_weather.g.dart
+++ b/lib/weather/use_case/get_weather.g.dart
@@ -6,14 +6,163 @@ part of 'get_weather.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$RequestDataImpl _$$RequestDataImplFromJson(Map<String, dynamic> json) =>
-    _$RequestDataImpl(
-      area: json['area'] as String,
-      dateTime: DateTime.parse(json['date'] as String),
-    );
-
 Map<String, dynamic> _$$RequestDataImplToJson(_$RequestDataImpl instance) =>
     <String, dynamic>{
       'area': instance.area,
       'date': instance.dateTime.toIso8601String(),
     };
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$getWeatherHash() => r'df1e32eeac724b1f878cdd72e6d1d6b370d84d61';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [getWeather].
+@ProviderFor(getWeather)
+const getWeatherProvider = GetWeatherFamily();
+
+/// See also [getWeather].
+class GetWeatherFamily extends Family<Weather> {
+  /// See also [getWeather].
+  const GetWeatherFamily();
+
+  /// See also [getWeather].
+  GetWeatherProvider call({
+    required String area,
+  }) {
+    return GetWeatherProvider(
+      area: area,
+    );
+  }
+
+  @override
+  GetWeatherProvider getProviderOverride(
+    covariant GetWeatherProvider provider,
+  ) {
+    return call(
+      area: provider.area,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'getWeatherProvider';
+}
+
+/// See also [getWeather].
+class GetWeatherProvider extends AutoDisposeProvider<Weather> {
+  /// See also [getWeather].
+  GetWeatherProvider({
+    required String area,
+  }) : this._internal(
+          (ref) => getWeather(
+            ref as GetWeatherRef,
+            area: area,
+          ),
+          from: getWeatherProvider,
+          name: r'getWeatherProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$getWeatherHash,
+          dependencies: GetWeatherFamily._dependencies,
+          allTransitiveDependencies:
+              GetWeatherFamily._allTransitiveDependencies,
+          area: area,
+        );
+
+  GetWeatherProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.area,
+  }) : super.internal();
+
+  final String area;
+
+  @override
+  Override overrideWith(
+    Weather Function(GetWeatherRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: GetWeatherProvider._internal(
+        (ref) => create(ref as GetWeatherRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        area: area,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<Weather> createElement() {
+    return _GetWeatherProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GetWeatherProvider && other.area == area;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, area.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin GetWeatherRef on AutoDisposeProviderRef<Weather> {
+  /// The parameter `area` of this provider.
+  String get area;
+}
+
+class _GetWeatherProviderElement extends AutoDisposeProviderElement<Weather>
+    with GetWeatherRef {
+  _GetWeatherProviderElement(super.provider);
+
+  @override
+  String get area => (origin as GetWeatherProvider).area;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/weather/use_case/get_weather.g.dart
+++ b/lib/weather/use_case/get_weather.g.dart
@@ -16,153 +16,19 @@ Map<String, dynamic> _$$RequestDataImplToJson(_$RequestDataImpl instance) =>
 // RiverpodGenerator
 // **************************************************************************
 
-String _$getWeatherHash() => r'df1e32eeac724b1f878cdd72e6d1d6b370d84d61';
-
-/// Copied from Dart SDK
-class _SystemHash {
-  _SystemHash._();
-
-  static int combine(int hash, int value) {
-    // ignore: parameter_assignments
-    hash = 0x1fffffff & (hash + value);
-    // ignore: parameter_assignments
-    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-    return hash ^ (hash >> 6);
-  }
-
-  static int finish(int hash) {
-    // ignore: parameter_assignments
-    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
-    // ignore: parameter_assignments
-    hash = hash ^ (hash >> 11);
-    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
-  }
-}
+String _$getWeatherHash() => r'5f2e85675aa657387462cacdd1398d32c44f9897';
 
 /// See also [getWeather].
 @ProviderFor(getWeather)
-const getWeatherProvider = GetWeatherFamily();
+final getWeatherProvider = AutoDisposeProvider<GetWeatherUseCase>.internal(
+  getWeather,
+  name: r'getWeatherProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$getWeatherHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
 
-/// See also [getWeather].
-class GetWeatherFamily extends Family<Weather> {
-  /// See also [getWeather].
-  const GetWeatherFamily();
-
-  /// See also [getWeather].
-  GetWeatherProvider call({
-    required String area,
-  }) {
-    return GetWeatherProvider(
-      area: area,
-    );
-  }
-
-  @override
-  GetWeatherProvider getProviderOverride(
-    covariant GetWeatherProvider provider,
-  ) {
-    return call(
-      area: provider.area,
-    );
-  }
-
-  static const Iterable<ProviderOrFamily>? _dependencies = null;
-
-  @override
-  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
-
-  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
-
-  @override
-  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
-      _allTransitiveDependencies;
-
-  @override
-  String? get name => r'getWeatherProvider';
-}
-
-/// See also [getWeather].
-class GetWeatherProvider extends AutoDisposeProvider<Weather> {
-  /// See also [getWeather].
-  GetWeatherProvider({
-    required String area,
-  }) : this._internal(
-          (ref) => getWeather(
-            ref as GetWeatherRef,
-            area: area,
-          ),
-          from: getWeatherProvider,
-          name: r'getWeatherProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$getWeatherHash,
-          dependencies: GetWeatherFamily._dependencies,
-          allTransitiveDependencies:
-              GetWeatherFamily._allTransitiveDependencies,
-          area: area,
-        );
-
-  GetWeatherProvider._internal(
-    super._createNotifier, {
-    required super.name,
-    required super.dependencies,
-    required super.allTransitiveDependencies,
-    required super.debugGetCreateSourceHash,
-    required super.from,
-    required this.area,
-  }) : super.internal();
-
-  final String area;
-
-  @override
-  Override overrideWith(
-    Weather Function(GetWeatherRef provider) create,
-  ) {
-    return ProviderOverride(
-      origin: this,
-      override: GetWeatherProvider._internal(
-        (ref) => create(ref as GetWeatherRef),
-        from: from,
-        name: null,
-        dependencies: null,
-        allTransitiveDependencies: null,
-        debugGetCreateSourceHash: null,
-        area: area,
-      ),
-    );
-  }
-
-  @override
-  AutoDisposeProviderElement<Weather> createElement() {
-    return _GetWeatherProviderElement(this);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return other is GetWeatherProvider && other.area == area;
-  }
-
-  @override
-  int get hashCode {
-    var hash = _SystemHash.combine(0, runtimeType.hashCode);
-    hash = _SystemHash.combine(hash, area.hashCode);
-
-    return _SystemHash.finish(hash);
-  }
-}
-
-mixin GetWeatherRef on AutoDisposeProviderRef<Weather> {
-  /// The parameter `area` of this provider.
-  String get area;
-}
-
-class _GetWeatherProviderElement extends AutoDisposeProviderElement<Weather>
-    with GetWeatherRef {
-  _GetWeatherProviderElement(super.provider);
-
-  @override
-  String get area => (origin as GetWeatherProvider).area;
-}
+typedef GetWeatherRef = AutoDisposeProviderRef<GetWeatherUseCase>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -14,7 +14,7 @@ class WeatherNotifier extends _$WeatherNotifier {
   Weather? build() => null;
 
   void update({required String area}) {
-    state = ref.read(getWeatherProvider)(area: 'tokyo');
+    state = ref.read(getWeatherProvider)(area: area);
   }
 }
 

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -14,7 +14,7 @@ class WeatherNotifier extends _$WeatherNotifier {
   Weather? build() => null;
 
   void update({required String area}) {
-    state = ref.read(getWeatherProvider(area: 'tokyo'));
+    state = ref.read(getWeatherProvider)(area: 'tokyo');
   }
 }
 

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -1,25 +1,20 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_training/data/weather.dart';
 import 'package:flutter_training/weather/use_case/get_weather.dart';
 import 'package:flutter_training/weather/weather_icon.dart';
 
-class WeatherScreen extends StatefulWidget {
-  const WeatherScreen(
-    GetWeather getWeather, {
-    required VoidCallback close,
-    super.key,
-  })  : _getWeather = getWeather,
-        _close = close;
+class WeatherScreen extends ConsumerStatefulWidget {
+  const WeatherScreen({required VoidCallback close, super.key}): _close = close;
 
-  final GetWeather _getWeather;
   final VoidCallback _close;
 
   @override
-  State<WeatherScreen> createState() => _WeatherScreenState();
+  ConsumerState<WeatherScreen> createState() => _WeatherScreenState();
 }
 
-class _WeatherScreenState extends State<WeatherScreen> {
+class _WeatherScreenState extends ConsumerState<WeatherScreen> {
   Weather? _weather;
 
   @override
@@ -42,7 +37,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
                     padding: const EdgeInsets.only(top: 80),
                     child: _ButtonsRow(
                       closeAction: widget._close,
-                      reloadAction: _reloadWeather,
+                      reloadAction: () => _reloadWeather(ref),
                     ),
                   ),
                 ),
@@ -54,13 +49,13 @@ class _WeatherScreenState extends State<WeatherScreen> {
     );
   }
 
-  void _reloadWeather() {
+  void _reloadWeather(WidgetRef ref) {
     try {
-      final weather = widget._getWeather(area: 'tokyo');
+      final weather = ref.read(getWeatherProvider(area: 'tokyo'));
       setState(() {
         _weather = weather;
       });
-    } on GetWeatherException catch(e) {
+    } on GetWeatherException catch (e) {
       unawaited(_showErrorDialog(e.message));
     }
   }
@@ -169,7 +164,7 @@ extension on GetWeatherException {
     return switch (this) {
       UnknownException() => 'Unknown error occurred. Please try again.',
       InvalidParameterException() =>
-      'Parameter is not valid. Please check your inputs and try again.',
+        'Parameter is not valid. Please check your inputs and try again.',
     };
   }
 }

--- a/lib/weather/weather_screen.g.dart
+++ b/lib/weather/weather_screen.g.dart
@@ -6,7 +6,7 @@ part of 'weather_screen.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$weatherNotifierHash() => r'3fdac934625fed2aeff45a101de947aea979083c';
+String _$weatherNotifierHash() => r'b79f9432bd10d0b42bc3cb43c35b175644a61b76';
 
 /// See also [WeatherNotifier].
 @ProviderFor(WeatherNotifier)

--- a/lib/weather/weather_screen.g.dart
+++ b/lib/weather/weather_screen.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_screen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$weatherNotifierHash() => r'3fdac934625fed2aeff45a101de947aea979083c';
+
+/// See also [WeatherNotifier].
+@ProviderFor(WeatherNotifier)
+final weatherNotifierProvider =
+    AutoDisposeNotifierProvider<WeatherNotifier, Weather?>.internal(
+  WeatherNotifier.new,
+  name: r'weatherNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$weatherNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WeatherNotifier = AutoDisposeNotifier<Weather?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: "9661b30b13a685efaee9f02e5d01ed9f2b423bd889d28a304d02d704aee69161"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.3"
   args:
     dependency: transitive
     description:
@@ -121,6 +129,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   clock:
     dependency: transitive
     description:
@@ -161,6 +185,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  custom_lint:
+    dependency: "direct dev"
+    description:
+      name: custom_lint
+      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.4"
+  custom_lint_builder:
+    dependency: transitive
+    description:
+      name: custom_lint_builder
+      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.4"
+  custom_lint_core:
+    dependency: transitive
+    description:
+      name: custom_lint_core
+      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.3"
   dart_style:
     dependency: transitive
     description:
@@ -198,6 +246,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "0f1974eff5bbe774bf1d870e406fc6f29e3d6f1c46bd9c58e7172ff68a785d7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -264,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: ed56fdc1f3a8ac924e717257621d09e9ec20e308ab6352a73a50a1d7a4d9158e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   http:
     dependency: transitive
     description:
@@ -440,6 +504,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: f21b32ffd26a36555e501b04f4a5dca43ed59e16343f1a30c13632b2351dfa4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
+  riverpod_analyzer_utils:
+    dependency: transitive
+    description:
+      name: riverpod_analyzer_utils
+      sha256: "8b71f03fc47ae27d13769496a1746332df4cec43918aeba9aff1e232783a780f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  riverpod_annotation:
+    dependency: "direct main"
+    description:
+      name: riverpod_annotation
+      sha256: e5e796c0eba4030c704e9dae1b834a6541814963292839dcf9638d53eba84f5c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  riverpod_generator:
+    dependency: "direct dev"
+    description:
+      name: riverpod_generator
+      sha256: d451608bf17a372025fc36058863737636625dfdb7e3cbf6142e0dfeb366ab22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  riverpod_lint:
+    dependency: "direct dev"
+    description:
+      name: riverpod_lint
+      sha256: "3c67c14ccd16f0c9d53e35ef70d06cd9d072e2fb14557326886bbde903b230a5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.10"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   shelf:
     dependency: transitive
     description:
@@ -485,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -493,6 +613,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -549,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_riverpod: ^2.5.1
   flutter_svg: ^2.0.10+1
   freezed_annotation: ^2.4.1
   go_router: ^14.1.1
   json_annotation: ^4.9.0
+  riverpod_annotation: ^2.3.5
   yumemi_weather:
     git:
       url: https://github.com/yumemi-inc/flutter-training-template.git
@@ -22,10 +24,13 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.9
+  custom_lint: ^0.6.4
   flutter_test:
     sdk: flutter
   freezed: ^2.5.2
   json_serializable: ^6.8.0
+  riverpod_generator: ^2.4.0
+  riverpod_lint: ^2.3.10
   yumemi_lints: ^2.0.0
 
 flutter:


### PR DESCRIPTION
## 課題

close #9 

## 対応箇所

- [x] [Riverpod](https://pub.dev/packages/riverpod) を導入して、天気予報画面の状態管理を見直す
  - DI の観点から `GetWeather` use case を Provider で提供するようにしました。
  - 天気予報状態である `Weather?` を管理する NotifierProvider を追加しました。
  - ↑ の Notifier の `update` メソッドで use case を呼び出して自身の状態を変更するようにしました。
- [x] アーキテクチャを見直し、ARCHITECTURE.md に記載する
  - 元々設計は考えながら作っていたので、アーキテクチャ自体は変更していません。

## 動作

動作に変更はありません。
強いて言えば `keepAlive: true` をしていないので、`LaunchScreen` に戻った際に今まで同様に状態がリセットされていることがわかります。