### PR TITLE
[Session/11] スレッドブロックを Isolate で回避

### DIFF
--- a/lib/util/show_loading_dialog.dart
+++ b/lib/util/show_loading_dialog.dart
@@ -18,14 +18,10 @@ Future<T> showLoadingDialog<T>(
 
   try {
     final result = await operation();
-    if (context.mounted) {
-      Navigator.of(context).pop();
-    }
     return result;
-  } on Exception catch (_) {
+  } finally {
     if (context.mounted) {
       Navigator.of(context).pop();
     }
-    rethrow;
   }
 }

--- a/lib/util/show_loading_dialog.dart
+++ b/lib/util/show_loading_dialog.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+Future<T> showLoadingDialog<T>(
+  BuildContext context,
+  Future<T> Function() operation,
+) async {
+  unawaited(
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const Center(
+        child: CircularProgressIndicator(),
+      ),
+    ),
+  );
+
+  try {
+    final result = await operation();
+    if (context.mounted) {
+      Navigator.of(context).pop();
+    }
+    return result;
+  } on Exception catch (_) {
+    if (context.mounted) {
+      Navigator.of(context).pop();
+    }
+    rethrow;
+  }
+}

--- a/lib/weather/use_case/get_weather.dart
+++ b/lib/weather/use_case/get_weather.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_training/data/weather.dart';
 import 'package:flutter_training/infrastructure/weather_api.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -33,17 +34,18 @@ final class InvalidParameterException extends GetWeatherException {
   String toString() => 'Parameter is not valid: ${super.toString()}';
 }
 
-typedef GetWeatherUseCase = Weather Function({required String area});
+typedef GetWeatherUseCase = Future<Weather> Function({required String area});
 
 @riverpod
 GetWeatherUseCase getWeather(GetWeatherRef ref) {
-  return ({required area}) {
+  return ({required area}) async {
     try {
       final request = _Request(area: area, dateTime: DateTime.now());
       final requestJsonString = jsonEncode(request.toJson());
 
+      final yumemiWeather = ref.read(yumemiWeatherProvider);
       final rawResponse =
-          ref.read(yumemiWeatherProvider).fetchWeather(requestJsonString);
+          await compute(yumemiWeather.syncFetchWeather, requestJsonString);
       final responseJson = jsonDecode(rawResponse) as Map<String, dynamic>;
       return Weather.fromJson(responseJson);
     } on YumemiWeatherError catch (e) {

--- a/lib/weather/use_case/get_weather.freezed.dart
+++ b/lib/weather/use_case/get_weather.freezed.dart
@@ -103,7 +103,7 @@ class __$$RequestDataImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable(createFactory: false)
-class _$RequestDataImpl implements _RequestData {
+class _$RequestDataImpl with DiagnosticableTreeMixin implements _RequestData {
   const _$RequestDataImpl(
       {required this.area, @JsonKey(name: 'date') required this.dateTime});
 
@@ -114,8 +114,17 @@ class _$RequestDataImpl implements _RequestData {
   final DateTime dateTime;
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return '_Request(area: $area, dateTime: $dateTime)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', '_Request'))
+      ..add(DiagnosticsProperty('area', area))
+      ..add(DiagnosticsProperty('dateTime', dateTime));
   }
 
   @override

--- a/lib/weather/use_case/get_weather.g.dart
+++ b/lib/weather/use_case/get_weather.g.dart
@@ -16,7 +16,7 @@ Map<String, dynamic> _$$RequestDataImplToJson(_$RequestDataImpl instance) =>
 // RiverpodGenerator
 // **************************************************************************
 
-String _$getWeatherHash() => r'619c66e7859a7911f3af8df46f5819debc822884';
+String _$getWeatherHash() => r'd213c84b8d556a43f26ff96163e469ac370ec236';
 
 /// See also [getWeather].
 @ProviderFor(getWeather)

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -45,7 +45,8 @@ class WeatherScreen extends ConsumerWidget {
                     padding: const EdgeInsets.only(top: 80),
                     child: _ButtonsRow(
                       closeAction: _close,
-                      reloadAction: () => _reloadWeather(context, ref),
+                      reloadAction: () =>
+                          unawaited(_reloadWeather(context, ref)),
                     ),
                   ),
                 ),
@@ -57,11 +58,14 @@ class WeatherScreen extends ConsumerWidget {
     );
   }
 
-  void _reloadWeather(BuildContext context, WidgetRef ref) {
+  Future<void> _reloadWeather(BuildContext context, WidgetRef ref) async {
     try {
-      ref.read(weatherNotifierProvider.notifier).update(area: 'tokyo');
+      await ref.read(weatherNotifierProvider.notifier).update(area: 'tokyo');
     } on GetWeatherException catch (e) {
-      unawaited(_showErrorDialog(context, e.message));
+      if (!context.mounted) {
+        return;
+      }
+      await _showErrorDialog(context, e.message);
     }
   }
 

--- a/lib/weather/weather_screen.dart
+++ b/lib/weather/weather_screen.dart
@@ -13,8 +13,8 @@ class WeatherNotifier extends _$WeatherNotifier {
   @override
   Weather? build() => null;
 
-  void update({required String area}) {
-    state = ref.read(getWeatherProvider)(area: area);
+  Future<void> update({required String area}) async {
+    state = await ref.read(getWeatherProvider)(area: area);
   }
 }
 

--- a/lib/weather/weather_screen.g.dart
+++ b/lib/weather/weather_screen.g.dart
@@ -6,7 +6,7 @@ part of 'weather_screen.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$weatherNotifierHash() => r'b79f9432bd10d0b42bc3cb43c35b175644a61b76';
+String _$weatherNotifierHash() => r'235a727dab936452bae916dbe0fabd799705904d';
 
 /// See also [WeatherNotifier].
 @ProviderFor(WeatherNotifier)

--- a/test/weather/use_case/get_weather_test.dart
+++ b/test/weather/use_case/get_weather_test.dart
@@ -25,7 +25,7 @@ void main() {
       );
 
   group('Test GetWeather UseCase', () {
-    test('正常レスポンスで適切な Weather が返却される', () {
+    test('正常レスポンスで適切な Weather が返却される', () async {
       // Arrange
       final container = createMockContainer();
       final date = DateTime(2024, 4);
@@ -37,13 +37,12 @@ void main() {
         "date":"${date.toIso8601String()}"
       }
       ''';
-      when(mockYumemiWeather.fetchWeather(any)).thenReturn(result);
+      when(mockYumemiWeather.syncFetchWeather(any)).thenReturn(result);
 
       // Act
-      final weather = container.read(getWeatherProvider)(area: 'tokyo');
+      final weather = await container.read(getWeatherProvider)(area: 'tokyo');
 
       // Assert
-      verify(mockYumemiWeather.fetchWeather(any)).called(1);
       expect(
         weather,
         Weather(
@@ -55,36 +54,30 @@ void main() {
       );
     });
 
-    test('YumemiWeather.unknown の場合は UnknownException', () {
+    test('YumemiWeather.unknown の場合は UnknownException', () async {
       // Arrange
       final container = createMockContainer();
-      when(mockYumemiWeather.fetchWeather(any))
+      when(mockYumemiWeather.syncFetchWeather(any))
           .thenThrow(YumemiWeatherError.unknown);
 
       // Act + Assert
       expect(
-        () => container.read(getWeatherProvider)(area: 'tokyo'),
+        () async => container.read(getWeatherProvider)(area: 'tokyo'),
         throwsA(isA<UnknownException>()),
       );
-
-      // Assert
-      verify(mockYumemiWeather.fetchWeather(any)).called(1);
     });
 
     test('YumemiWeather.invalidParameter の場合は InvalidParameterException', () {
       // Arrange
       final container = createMockContainer();
-      when(mockYumemiWeather.fetchWeather(any))
+      when(mockYumemiWeather.syncFetchWeather(any))
           .thenThrow(YumemiWeatherError.invalidParameter);
 
       // Act + Assert
       expect(
-        () => container.read(getWeatherProvider)(area: 'tokyo'),
+        () async => container.read(getWeatherProvider)(area: 'tokyo'),
         throwsA(isA<InvalidParameterException>()),
       );
-
-      // Assert
-      verify(mockYumemiWeather.fetchWeather(any)).called(1);
     });
   });
 }

--- a/test/weather/weather_notifier_test.dart
+++ b/test/weather/weather_notifier_test.dart
@@ -11,7 +11,7 @@ class MockCallback extends Mock {
 }
 
 void main() {
-  test('GetWeather の状態に応じて WeatherState が適切に更新される', () {
+  test('GetWeather の状態に応じて WeatherState が適切に更新される', () async {
     final date = DateTime(2024, 4);
     final result1 = Weather(
       condition: WeatherCondition.cloudy,
@@ -32,10 +32,10 @@ void main() {
       date: date,
     );
     final results = [
-      () => result1,
-      () => result2,
-      () => throw const UnknownException(),
-      () => result3,
+      () async => result1,
+      () async => result2,
+      () async => throw const UnknownException(),
+      () async => result3,
     ];
 
     final callback = MockCallback();
@@ -44,7 +44,7 @@ void main() {
     final container = createContainer(
       overrides: [
         getWeatherProvider.overrideWith(
-          (ref) => ({required area}) => results.removeAt(0).call(),
+          (ref) => ({required area}) async => results.removeAt(0).call(),
         ),
       ],
     );
@@ -58,15 +58,21 @@ void main() {
     );
 
     // Act
-    container.read(weatherNotifierProvider.notifier).update(area: 'tokyo');
-    container.read(weatherNotifierProvider.notifier).update(area: 'tokyo');
+    await container
+        .read(weatherNotifierProvider.notifier)
+        .update(area: 'tokyo');
+    await container
+        .read(weatherNotifierProvider.notifier)
+        .update(area: 'tokyo');
     expect(
       () => container
           .read(weatherNotifierProvider.notifier)
           .update(area: 'tokyo'),
       throwsA(isA<UnknownException>()),
     );
-    container.read(weatherNotifierProvider.notifier).update(area: 'tokyo');
+    await container
+        .read(weatherNotifierProvider.notifier)
+        .update(area: 'tokyo');
 
     // Assert
     verifyInOrder([

--- a/test/weather/weather_screen_test.dart
+++ b/test/weather/weather_screen_test.dart
@@ -90,7 +90,8 @@ void main() {
       );
 
       await tester.tap(find.text('Reload'));
-      await tester.pumpAndSettle();
+      // `CircularProgressIndicator` で `pumpAndSettle` だとタイムアウトになるので `pump` で代替
+      await tester.pump(Durations.long1);
 
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(find.text('Error'), findsOneWidget);

--- a/test/weather/weather_screen_test.dart
+++ b/test/weather/weather_screen_test.dart
@@ -46,8 +46,8 @@ void main() {
           ProviderScope(
             overrides: [
               getWeatherProvider.overrideWith(
-                (ref) =>
-                    ({required area}) => weather.copyWith(condition: condition),
+                (ref) => ({required area}) async =>
+                    weather.copyWith(condition: condition),
               ),
             ],
             child: MaterialApp(


### PR DESCRIPTION
## 課題

close #12 

## 対応箇所

- [x] 使用する API を fetchWeather() から syncFetchWeather() に変更する
- [x] API の処理が戻るまで [CircularProgressIndicator](https://api.flutter.dev/flutter/material/CircularProgressIndicator-class.html) を表示する

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| <img width=300 src="https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/thread_block/demo.gif?raw=true&rgh-link-date=2024-05-08T01%3A34%3A07Z">      | <video width=300 src="https://github.com/daichikuwa0618/flutter-weather-app/assets/31601805/647369f3-ee82-421f-aedd-dad8417fac10">    |





